### PR TITLE
Add .gitignore, hide node_modules directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Nice to have the .gitignore file in place and hiding the node_modules directory before running `npm install`.